### PR TITLE
Create Promise runtime only once.

### DIFF
--- a/sqlite.js
+++ b/sqlite.js
@@ -34,9 +34,13 @@ config.forEach(entry => {
   originalFns[prototype + "." + fn] = originalFn;
 });
 
-function enablePromiseRuntime(enable){
-  if (enable){
-    createPromiseRuntime();
+let promiseEnabled = false;
+function enablePromiseRuntime(enable) {
+  if (enable) {
+    if (!promiseEnabled) {
+      promiseEnabled = true;
+      createPromiseRuntime();
+    }
   } else {
     createCallbackRuntime();
   }


### PR DESCRIPTION
Added a flag to check if the promise runtime has already been enabled and if so don't call the `createPromiseRuntime`  again.