### PR TITLE
Fix crash if SQLCipher key is nil in SQLite.m

### DIFF
--- a/src/ios/SQLite.m
+++ b/src/ios/SQLite.m
@@ -218,6 +218,7 @@ RCT_EXPORT_METHOD(open: (NSDictionary *) options success:(RCTResponseSenderBlock
         
           // for SQLCipher version:
           NSString *dbkey = options[@"key"];
+          if (dbkey == nil) dbkey = @"";
           const char *key = NULL;
           if (dbkey != NULL) key = [dbkey UTF8String];
           if (key != NULL) sqlite3_key(db, key, strlen(key));


### PR DESCRIPTION
If the SQLCipher key is nil, it'll cause a crash within the iOS app. This is because SQLite.m doesn't check if the encryption key is nil. This has been changed to set the key to an empty string if it's found to be nil.