### PR TITLE
Update sqlcipher to version 3.5.5

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -34,5 +34,5 @@ allprojects {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.14.+'
-    compile 'net.zetetic:android-database-sqlcipher:3.5.3@aar'
+    compile 'net.zetetic:android-database-sqlcipher:3.5.5@aar'
 }


### PR DESCRIPTION
The current version of sqlcipher 3.5.4 doesn't include x86_64 and arm64-v8a binaries hence upgrading to the closest minor version that include 64 bit android binaries.