### PR TITLE
fix: remove ignoring null values for the row

### DIFF
--- a/platforms/windows/SQLitePlugin/SQLitePluginModule.cs
+++ b/platforms/windows/SQLitePlugin/SQLitePluginModule.cs
@@ -488,10 +488,7 @@ namespace SQLitePlugin
             {
                 var columnName = _sqliteAPI.ColumnName16(statement, i);
                 JSValue columnValue = ExtractColumn(statement, i);
-                if (!columnValue.IsNull)
-                {
-                    row[columnName] = columnValue;
-                }
+                row[columnName] = columnValue;
             }
             return row;
         }


### PR DESCRIPTION
null values from table column are getting ignored when we fetch the record from DB. So only the fields having values are available the row records. It creates some issues in our functionality where the Mobile is having all fields in row records.